### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol server for ArangoDB
 
 This is a TypeScript-based MCP server that provides database interaction capabilities through ArangoDB. It implements core database operations and allows seamless integration with ArangoDB through MCP tools. You can use it wih Claude app and also extension for VSCode that works with mcp like Cline!
 
+<a href="https://glama.ai/mcp/servers/soeqalh2v9"><img width="380" height="200" src="https://glama.ai/mcp/servers/soeqalh2v9/badge" alt="Server for ArangoDB MCP server" /></a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for ArangoDB](https://glama.ai/mcp/servers/soeqalh2v9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/soeqalh2v9"><img width="380" height="200" src="https://glama.ai/mcp/servers/soeqalh2v9/badge" alt="Server for ArangoDB MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.